### PR TITLE
Fix: Remove '%' operator from highlights query

### DIFF
--- a/tree-sitter-senbonzakura/queries/highlights.scm
+++ b/tree-sitter-senbonzakura/queries/highlights.scm
@@ -60,7 +60,6 @@
 ">=" @operator
 "=" @operator
 "->" @operator
-"%" @operator
 
 ; Punctuation
 "(" @punctuation.bracket


### PR DESCRIPTION
Removed '%' operator from highlights.